### PR TITLE
Add ignore errors when un-installing pip

### DIFF
--- a/deploy/linux/roles/prepare/tasks/installSupervisord.yml
+++ b/deploy/linux/roles/prepare/tasks/installSupervisord.yml
@@ -18,6 +18,7 @@
     - name: Uninstalling system pip
       shell: pip uninstall -y pip
       become: yes
+      ignore_errors: true
       when: pip_installed.stdout|int == 1 and pip_local.stdout|int == 0
     - name: Installing latest pip - fetch
       shell: curl -sSL https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py


### PR DESCRIPTION
## Summary
This PR add ignore errors to installing Pip.  This was uncovered when testing on the latest Linux2.  Without this change the installation of Javatron fails.

## Checklist
- [ ] Documentation updated
- [ ] Unit tests updated
- [ ] User Acceptance Tests updated

## Deployment Configuration for Testing
```

{
    "global_tags": {
        "dxOwningTeam": "DemoX",
        "dxEnvironment": "development",
        "dxDepartment": "Area51",
        "dxProduct": "Databases"
    },
    "services": [
        {
            "id": "java1",
            "source_repository": "-b add_ignore_errors_when_uninstalling_pip https://github.com/newrelic/demo-javatron.git",
            "deploy_script_path": "deploy/linux/roles",
            "port": 6001,
            "destinations": [ "host1" ]
        }
    ],
    "resources": [
        {
            "id": "host1",
            "provider": "aws",
            "type": "ec2",
            "size": "t2.micro",
            "ami_name": "amazonlinux-2-base*"
        }
    ],
    "instrumentations": {
    }
}


```