### PR TITLE
allow controlling the tomcat version from deploy config via params

### DIFF
--- a/deploy/debian/roles/prepare/tasks/installTomcat.yml
+++ b/deploy/debian/roles/prepare/tasks/installTomcat.yml
@@ -5,21 +5,27 @@
   become: yes
   ignore_errors: yes
 
+- set_fact: tomcat_download_url="https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.34/bin/apache-tomcat-9.0.34.tar.gz"
+  when: tomcat_download_url is undefined
+
+- set_fact: tomcat_version_name="apache-tomcat-9.0.34"
+  when: tomcat_version_name is undefined
+
 - name: Download
-  shell: "wget https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.34/bin/apache-tomcat-9.0.34.tar.gz -P /tmp"
+  shell: "wget {{ tomcat_download_url }} -P /tmp"
 
 - name: Unpacking
-  shell: "tar xf /tmp/apache-tomcat-9*.tar.gz -C /opt/tomcat"
+  shell: "tar xf /tmp/{{ tomcat_version_name }}.tar.gz -C /opt/tomcat"
   become: yes
 
 - name: detect if tomcat latest link exist
-  stat: 
+  stat:
     path: /opt/tomcat/latest
   become: yes
   register: tomcat_link
 
 - name: Symlink
-  shell: "ln -s /opt/tomcat/apache-tomcat-9.0.34 /opt/tomcat/latest"
+  shell: "ln -s /opt/tomcat/{{ tomcat_version_name }} /opt/tomcat/latest"
   when: tomcat_link is not defined or tomcat_link.stat.islnk is not defined
   become: yes
 

--- a/deploy/linux/roles/prepare/tasks/installTomcat.yml
+++ b/deploy/linux/roles/prepare/tasks/installTomcat.yml
@@ -5,21 +5,27 @@
   become: yes
   ignore_errors: yes
 
+- set_fact: tomcat_download_url="https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.34/bin/apache-tomcat-9.0.34.tar.gz"
+  when: tomcat_download_url is undefined
+
+- set_fact: tomcat_version_name="apache-tomcat-9.0.34"
+  when: tomcat_version_name is undefined
+
 - name: Download
-  shell: "wget https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.34/bin/apache-tomcat-9.0.34.tar.gz -P /tmp"
+  shell: "wget {{ tomcat_download_url }} -P /tmp"
 
 - name: Unpacking
-  shell: "tar xf /tmp/apache-tomcat-9*.tar.gz -C /opt/tomcat"
+  shell: "tar xf /tmp/{{ tomcat_version_name }}.tar.gz -C /opt/tomcat"
   become: yes
 
 - name: detect if tomcat latest link exist
-  stat: 
+  stat:
     path: /opt/tomcat/latest
   become: yes
   register: tomcat_link
 
 - name: Symlink
-  shell: "ln -s /opt/tomcat/apache-tomcat-9.0.34 /opt/tomcat/latest"
+  shell: "ln -s /opt/tomcat/{{ tomcat_version_name }} /opt/tomcat/latest"
   when: tomcat_link is not defined or tomcat_link.stat.islnk is not defined
   become: yes
 


### PR DESCRIPTION
## Summary

This change allows for controlling the versions of Tomcat installed from the deploy configuration via params.

## Checklist
[NOTE]: # ( Just check the ones applicable to this pull request. )
- [ ] Documentation updated
- [ ] Unit tests updated
- [ ] User Acceptance Tests updated

## Deployment Configuration for Testing

{
    "services": [
        {
            "id": "java1",
            "source_repository": "-b allow_deployment_config_to_controll_tomcat_version https://github.com/newrelic/demo-simulator.git",
            "deploy_script_path": "deploy/linux/roles",
            "port": 6001,
            "destinations": [ "host1" ],
            "params": {
                "tomcat_download_url": "https://archive.apache.org/dist/tomcat/tomcat-8/v8.5.45/bin/apache-tomcat-8.5.45.tar.gz",
                "tomcat_version_name": "apache-tomcat-8.5.45"
            }
        }
    ],
    "resources": [
        {
            "id": "host1",
            "provider": "aws",
            "type": "ec2",
            "size": "t2.micro"
        }
    ],
}

