### PR TITLE
Bumped maven to 3.8.3 & added insecure flag to mirror download url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ javatron/target/*
 *.local*
 
 *.DS_Store
+
+*.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ RUN mv jdk-14.0.1 /opt/
 ENV JAVA_HOME=/opt/jdk-14.0.1
 ENV PATH=$PATH:$JAVA_HOME/bin
 ## Maven
-RUN curl -O https://mirrors.ocf.berkeley.edu/apache/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.tar.gz
-RUN tar xzvf apache-maven-3.8.1-bin.tar.gz
-RUN mv apache-maven-3.8.1 /opt/
+RUN curl -O --insecure https://mirrors.ocf.berkeley.edu/apache/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.tar.gz
+RUN tar xzvf apache-maven-3.8.3-bin.tar.gz
+RUN mv apache-maven-3.8.3 /opt/
 ENV PATH=$PATH:/opt/apache-maven-3.8.1/bin
 
 # Tomcat

--- a/deploy/debian/roles/prepare/tasks/installMaven.yml
+++ b/deploy/debian/roles/prepare/tasks/installMaven.yml
@@ -2,10 +2,10 @@
 
 - name: set facts for maven version
   set_fact:
-    maven_version: 3.8.1
+    maven_version: 3.8.3
 
 - name: Download
-  shell: "curl -O https://mirrors.ocf.berkeley.edu/apache/maven/maven-3/{{ maven_version }}/binaries/apache-maven-{{ maven_version }}-bin.tar.gz"
+  shell: "curl -O --insecure https://mirrors.ocf.berkeley.edu/apache/maven/maven-3/{{ maven_version }}/binaries/apache-maven-{{ maven_version }}-bin.tar.gz"
 
 - name: Unpacking
   shell: "tar xzvf apache-maven-{{ maven_version }}-bin.tar.gz"

--- a/deploy/linux/roles/prepare/tasks/installMaven.yml
+++ b/deploy/linux/roles/prepare/tasks/installMaven.yml
@@ -2,10 +2,10 @@
 
 - name: set facts for maven version
   set_fact:
-    maven_version: 3.8.1
+    maven_version: 3.8.3
 
 - name: Download
-  shell: "curl -O https://mirrors.ocf.berkeley.edu/apache/maven/maven-3/{{ maven_version }}/binaries/apache-maven-{{ maven_version }}-bin.tar.gz"
+  shell: "curl -O --insecure https://mirrors.ocf.berkeley.edu/apache/maven/maven-3/{{ maven_version }}/binaries/apache-maven-{{ maven_version }}-bin.tar.gz"
 
 - name: Unpacking
   shell: "tar xzvf apache-maven-{{ maven_version }}-bin.tar.gz"


### PR DESCRIPTION
## Summary

[NOTE]: # ( Provide a brief overview of the changes. )

## Checklist
[NOTE]: # ( Just check the ones applicable to this pull request. )
- [ ] Documentation updated
- [ ] Unit tests updated
- [ ] User Acceptance Tests updated

## Related Issues
### [open-install-library](https://github.com/newrelic/open-install-library) test failures  
 - The maven version at this mirror was patched (3.8.1 => 3.8.3) which caused test failures.  PR is a version bump and addition of `--insecure` flag on download mirror 
