### PR TITLE
update to latest version of log4j

### DIFF
--- a/javatron/pom.xml
+++ b/javatron/pom.xml
@@ -65,13 +65,13 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.13.3</version>
+      <version>2.15.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.13.3</version>
+      <version>2.15.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
* update to latest version of log4j which isn't vulnerable per [this post](https://www.randori.com/blog/cve-2021-44228/)