### PR TITLE
fix: rsync needs apt update before install

### DIFF
--- a/deploy/debian/roles/prepare/tasks/installDependencies.yml
+++ b/deploy/debian/roles/prepare/tasks/installDependencies.yml
@@ -1,3 +1,7 @@
+- name: Get latest
+  run: |
+    sudo apt-get update -y
+
 - name: Get install dependencies
   package:
     name: '{{ packages }}'

--- a/user_acceptance_tests/deploy_configs/happy-aws-debian.deploy.config.json
+++ b/user_acceptance_tests/deploy_configs/happy-aws-debian.deploy.config.json
@@ -17,8 +17,8 @@
         "id": "host",
         "provider": "aws",
         "type": "ec2",
-        "size": "t2.micro",
-        "ami_name": "debian-10-amd64-2021????-???-*",
+        "size": "t3.micro",
+        "ami_name": "debian-10-amd64-202?????-*",
         "user_name": "admin"
       }
     ]


### PR DESCRIPTION
## Summary
rsync install needs apt-get update before