### PR TITLE
Bump Maven version to 3.8.7

### DIFF
--- a/.github/workflows/user_acceptance_tests.yml
+++ b/.github/workflows/user_acceptance_tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: checkout repo
         uses: actions/checkout@v2
 
-      - uses: actions/setup-ruby@v1
+      - uses: actions/setup-ruby
         with:
           ruby-version: 2.7
 

--- a/.github/workflows/user_acceptance_tests.yml
+++ b/.github/workflows/user_acceptance_tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: checkout repo
         uses: actions/checkout@v2
 
-      - uses: actions/setup-ruby
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
 

--- a/deploy/debian/roles/prepare/tasks/installMaven.yml
+++ b/deploy/debian/roles/prepare/tasks/installMaven.yml
@@ -2,7 +2,7 @@
 
 - name: set facts for maven version
   set_fact:
-    maven_version: 3.8.6
+    maven_version: 3.8.7
 
 - name: Download
   shell: "curl -O --insecure https://mirrors.ocf.berkeley.edu/apache/maven/maven-3/{{ maven_version }}/binaries/apache-maven-{{ maven_version }}-bin.tar.gz"

--- a/deploy/linux/roles/prepare/tasks/installMaven.yml
+++ b/deploy/linux/roles/prepare/tasks/installMaven.yml
@@ -2,7 +2,7 @@
 
 - name: set facts for maven version
   set_fact:
-    maven_version: 3.8.6
+    maven_version: 3.8.7
 
 - name: Download
   shell: "curl -O --insecure https://mirrors.ocf.berkeley.edu/apache/maven/maven-3/{{ maven_version }}/binaries/apache-maven-{{ maven_version }}-bin.tar.gz"


### PR DESCRIPTION
## Summary

Bumps Maven version to 3.8.7 as the download link for 3.8.6 no longer exists.

## Checklist
- [ ] Documentation updated
- [ ] Unit tests updated
- [ ] User Acceptance Tests updated

## Deployment Configuration for Testing

## Related Issues

## Related Pull Requests
https://github.com/newrelic/open-install-library/pull/850

## Reviewers
@Julien4218 
