### PR TITLE
fix: Upgrade Maven version to fix OIL failing tests

### DIFF
--- a/deploy/debian/roles/prepare/tasks/installMaven.yml
+++ b/deploy/debian/roles/prepare/tasks/installMaven.yml
@@ -2,7 +2,7 @@
 
 - name: set facts for maven version
   set_fact:
-    maven_version: 3.8.8
+    maven_version: 3.9.10
 
 - name: Download
   shell: "curl -O --insecure https://mirrors.ocf.berkeley.edu/apache/maven/maven-3/{{ maven_version }}/binaries/apache-maven-{{ maven_version }}-bin.tar.gz"

--- a/deploy/linux/roles/prepare/tasks/installMaven.yml
+++ b/deploy/linux/roles/prepare/tasks/installMaven.yml
@@ -2,7 +2,7 @@
 
 - name: set facts for maven version
   set_fact:
-    maven_version: 3.8.8
+    maven_version: 3.9.10
 
 - name: Download
   shell: "curl -O --insecure https://mirrors.ocf.berkeley.edu/apache/maven/maven-3/{{ maven_version }}/binaries/apache-maven-{{ maven_version }}-bin.tar.gz"


### PR DESCRIPTION
## Summary

This PR upgrades maven version, since OIL tests are failing to download/unzip the 3.8.8 mv version since this version seems no longer available in the [OCF mirrors site](https://mirrors.ocf.berkeley.edu/apache/maven/maven-3/). 

Sample test failure - https://github.com/newrelic/open-install-library/actions/runs/15971168817/job/45042504621
