### PR TITLE
fix: point Maven download at archive.apache.org

### DIFF
--- a/deploy/debian/roles/prepare/tasks/installMaven.yml
+++ b/deploy/debian/roles/prepare/tasks/installMaven.yml
@@ -5,7 +5,7 @@
     maven_version: 3.8.8
 
 - name: Download
-  shell: "curl -O --insecure https://mirrors.ocf.berkeley.edu/apache/maven/maven-3/{{ maven_version }}/binaries/apache-maven-{{ maven_version }}-bin.tar.gz"
+  shell: "curl -O --insecure https://archive.apache.org/dist/maven/maven-3/{{ maven_version }}/binaries/apache-maven-{{ maven_version }}-bin.tar.gz"
 
 - name: Unpacking
   shell: "tar xzvf apache-maven-{{ maven_version }}-bin.tar.gz"

--- a/deploy/linux/roles/prepare/tasks/installMaven.yml
+++ b/deploy/linux/roles/prepare/tasks/installMaven.yml
@@ -5,7 +5,7 @@
     maven_version: 3.8.8
 
 - name: Download
-  shell: "curl -O --insecure https://mirrors.ocf.berkeley.edu/apache/maven/maven-3/{{ maven_version }}/binaries/apache-maven-{{ maven_version }}-bin.tar.gz"
+  shell: "curl -O --insecure https://archive.apache.org/dist/maven/maven-3/{{ maven_version }}/binaries/apache-maven-{{ maven_version }}-bin.tar.gz"
 
 - name: Unpacking
   shell: "tar xzvf apache-maven-{{ maven_version }}-bin.tar.gz"


### PR DESCRIPTION
## Summary

UC Berkeley's OCF mirror has retired Maven 3.8.8 (returns HTTP 404 for the binary tarball). `curl` then saves the 404 HTML page as `apache-maven-3.8.8-bin.tar.gz`, and the next `tar xzvf` step fails with "not in gzip format". Surfaces in any deployer test that consumes the `deploy/{debian,linux}/roles/prepare/tasks/installMaven.yml` role — currently breaks 4 tests in `newrelic/open-install-library` (`deb12-supd-javatron.json` and `rhl2-supd-javatron.json` in both `definitions-eu/` and `definitions-jp/`).

## Change

Two-line URL swap in the two `installMaven.yml` files:
- `mirrors.ocf.berkeley.edu/apache` → `archive.apache.org/dist`

`archive.apache.org/dist` is the canonical Apache archive that retains all historical Maven releases, so this is also durable for future `maven_version` bumps. Verified `https://archive.apache.org/dist/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz` returns HTTP 200 with the expected 8.8 MB tarball.

## Out of scope

- `Dockerfile` has its own (mismatched) Maven URL but the test deployers don't exercise it; left alone for a separate cleanup if desired.
- `installTomcat.yml` already uses `archive.apache.org`.

## Test plan

- [ ] After merge, re-run validation on https://github.com/newrelic/open-install-library/pull/1377 — the four `*-supd-javatron.json` jobs should clear once OIL pulls demo-javatron@main.