### PR TITLE
fix: install superlance on debian variant for memmon eventlistener

### DIFF
--- a/deploy/debian/roles/prepare/tasks/installSupervisord.yml
+++ b/deploy/debian/roles/prepare/tasks/installSupervisord.yml
@@ -7,6 +7,21 @@
       ignore_errors: yes
       become: yes
 
+    # superlance provides /usr/local/bin/memmon, referenced in supervisord.conf
+    # by the [eventlistener:memmon{{ service_id }}] entry. apt's `supervisor`
+    # package does not include it. The linux/ variant installs it via pip;
+    # debian/ was missing this step, causing `supervisorctl start memmonjava1`
+    # to fail with "ERROR (no such file)".
+    - name: install pip3 for superlance
+      package:
+        name: python3-pip
+        state: present
+      become: yes
+
+    - name: install superlance (provides memmon)
+      shell: pip3 install --break-system-packages -U superlance
+      become: yes
+
     - name: Start supervisord
       service:
         name: '{{ item }}'


### PR DESCRIPTION
## Summary

`supervisord.conf` templates an `[eventlistener:memmon{service_id}]` entry that calls the `memmon` binary to restart the supervised process if memory exceeds 600MB. `memmon` is shipped by the **`superlance`** Python package — not by apt's `supervisor` package.

The `deploy/linux/` variant (RHEL/AmazonLinux) already installs `superlance` via pip in `installSupervisord.yml`. The `deploy/debian/` variant was missing this step, so `supervisorctl start memmonjava1` fails with `ERROR (no such file)` on any debian-family deploy.

This breaks 4 tests in `newrelic/open-install-library` that consume `deploy/debian/roles` (the `*-supd-javatron.json` family in `definitions-eu/` and `definitions-jp/`).

## Change

Add two tasks to `deploy/debian/roles/prepare/tasks/installSupervisord.yml`:
1. `apt install python3-pip` (Debian 12 ships pip3 separately from python3)
2. `pip3 install --break-system-packages -U superlance`

`--break-system-packages` is required because Debian 12 enforces PEP 668 (the externally-managed-environment marker) on system Python.

## Test plan

- [ ] Re-run validation on https://github.com/newrelic/open-install-library/pull/1377; the 4 `*-supd-javatron.json` jobs should clear once OIL pulls demo-javatron@main with this fix.