### PR TITLE
fix: symlink memmon into /usr/bin on debian variant

### DIFF
--- a/deploy/debian/roles/prepare/tasks/installSupervisord.yml
+++ b/deploy/debian/roles/prepare/tasks/installSupervisord.yml
@@ -22,6 +22,26 @@
       shell: pip3 install --break-system-packages -U superlance
       become: yes
 
+    # pip3 installs the memmon entry-point script under /usr/local/bin, but
+    # the apt-installed `supervisor` daemon on Debian 12 starts via systemd
+    # with a PATH that does not always include /usr/local/bin. Symlinking
+    # into /usr/bin guarantees memmon is on the daemon's PATH at runtime
+    # (so `supervisorctl start memmonjava1` doesn't ENOENT).
+    - name: locate memmon after superlance install
+      shell: which memmon
+      register: memmon_path
+      become: yes
+      changed_when: false
+
+    - name: symlink memmon into /usr/bin for supervisor PATH
+      file:
+        src: "{{ memmon_path.stdout }}"
+        dest: /usr/bin/memmon
+        state: link
+        force: yes
+      when: memmon_path.stdout != "/usr/bin/memmon"
+      become: yes
+
     - name: Start supervisord
       service:
         name: '{{ item }}'


### PR DESCRIPTION
## Summary

Follow-up to #44. The pip3 install of `superlance` lands `memmon` at `/usr/local/bin/memmon` on Debian 12, but the apt-installed `supervisor` systemd unit starts the daemon with a `PATH` that does not always include `/usr/local/bin`. When `supervisord` forks the `[eventlistener:memmon{service_id}]` subprocess, the `exec` of `memmon` fails with ENOENT — surfaces as `supervisorctl start memmonjava1: ERROR (no such file)`.

Confirmed against newrelic/open-install-library validation runs after #44 was merged: same failure as before, even though `superlance` is installed.

## Change

Two tasks added after the superlance install:

1. `which memmon` — registers the actual install path pip3 chose.
2. Symlink it into `/usr/bin/memmon` — `/usr/bin` is universally on PATH for shell- and systemd-spawned processes alike. Skipped if already there.

## Test plan

- [ ] Re-run validation on https://github.com/newrelic/open-install-library/pull/1377 after merge — the `*-supd-javatron.json` jobs (EU + JP) should clear.