### PR TITLE
fix: tolerate 'already started' on memmon eventlistener start

### DIFF
--- a/deploy/debian/roles/start/tasks/main.yml
+++ b/deploy/debian/roles/start/tasks/main.yml
@@ -33,5 +33,12 @@
   args:
     chdir: /etc/supervisor/conf.d
   become: true
+  register: memmon_start
+  # eventlisteners default to autostart=true, so `supervisorctl add memmonX`
+  # already starts memmonX before this task runs. Tolerate the resulting
+  # "already started" stdout (rc=1) — only fail on real errors.
+  failed_when:
+    - memmon_start.rc != 0
+    - "'already started' not in memmon_start.stdout"
 
 - include_tasks: cronjob.yml


### PR DESCRIPTION
## Summary

Final follow-up after #44 (superlance install) and #45 (memmon symlink). With memmon now installed and on PATH, the `supervisorctl start memmonjava1` task in `deploy/debian/roles/start/tasks/main.yml` fails with rc=1 / `memmonjava1: ERROR (already started)`.

Cause: supervisor eventlisteners default to `autostart=true`, so `supervisorctl add memmonX` (the preceding task) also starts memmonX before this start task runs. The explicit start is then redundant and produces a non-zero rc on the second attempt.

## Change

Adds `register: memmon_start` and a `failed_when` clause that tolerates rc=1 when stdout contains `already started` — fails on any other `supervisorctl` error. No behaviour change for fresh adds.

## Verification

Confirmed against newrelic/open-install-library validation runs after #45: error mode flipped from `no such file` to `already started`, and is the only remaining failure for the four `*-supd-javatron` tests across `definitions-eu/` and `definitions-jp/`.

## Test plan

- [ ] Re-run validation on https://github.com/newrelic/open-install-library/pull/1377 after merge — the four `*-supd-javatron.json` jobs should clear.