### PR TITLE
fix: install cron on debian to satisfy start-phase crontab usage

### DIFF
--- a/deploy/debian/roles/prepare/tasks/installDependencies.yml
+++ b/deploy/debian/roles/prepare/tasks/installDependencies.yml
@@ -9,4 +9,17 @@
   vars:
     packages:
       - rsync
+      # Debian 12 (Bookworm) does not ship cron by default. The start-phase
+      # cronjob.yml writes a crontab entry to drive periodic traffic to the
+      # supervised service; without `cron` installed, `crontab` is not found
+      # (rc=127) and the start phase fails. Linux/RHEL variant has cronie
+      # pre-installed via the AmazonLinux2 AMI, so this gap is debian-only.
+      - cron
+  become: yes
+
+- name: Ensure cron service is running
+  service:
+    name: cron
+    state: started
+    enabled: yes
   become: yes


### PR DESCRIPTION
## Summary

Last-layer rot found by `newrelic/open-install-library` validation runs after #44 (`superlance` install), #45 (memmon symlink), #46 (already-started tolerance) unblocked the memmon eventlistener path.

**Debian 12 (Bookworm) does not ship `cron` by default.** The start-phase `cronjob.yml` task writes a crontab entry to drive periodic traffic against the supervised service; without `cron` installed, `/bin/sh` exits 127 with `crontab: not found` and the start phase fails. The linux/RHEL variant works because Amazon Linux 2 ships `cronie` in the base AMI, so this gap is debian-only.

## Change

`deploy/debian/roles/prepare/tasks/installDependencies.yml`:
- Add `cron` to the apt packages list.
- Add a `service: name=cron state=started enabled=yes` task so the daemon picks up the crontab entry written by `cronjob.yml`.

## Test plan

- [ ] Re-run validation on https://github.com/newrelic/open-install-library/pull/1377 after merge — should be the final fix needed for the four `*-supd-javatron.json` jobs.